### PR TITLE
Add preflop simulator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
 # hello-world
 My First repository
 Now I am Adding new Staff
+
+## Preflop Simulator
+
+This repository includes a simple Monte Carlo simulator for Texas Hold'em preflop situations. Use `preflop_sim.py` to estimate win, tie, and equity percentages for a given starting hand.
+
+### Usage
+
+```bash
+python3 preflop_sim.py "As Ks" [num_opponents] [iterations]
+```
+
+- `num_opponents` defaults to `1` if omitted.
+- `iterations` defaults to `10000` if omitted.
+
+Example:
+
+```bash
+python3 preflop_sim.py "As Ks" 1 100000
+```
+
+This will output estimated percentages for Ace-King suited against one random opponent.

--- a/preflop_sim.py
+++ b/preflop_sim.py
@@ -1,0 +1,60 @@
+import sys
+import random
+from treys import Deck, Evaluator, Card
+
+
+def parse_hand(hand_str):
+    parts = hand_str.split()
+    if len(parts) != 2:
+        raise ValueError("Hand must contain two cards like 'As Ks'")
+    return [Card.new(parts[0]), Card.new(parts[1])]
+
+
+def simulate(hand_str, num_opponents=1, iterations=10000):
+    hero_cards = parse_hand(hand_str)
+    evaluator = Evaluator()
+    wins = 0
+    ties = 0
+
+    for _ in range(iterations):
+        deck = Deck()
+        for c in hero_cards:
+            deck.cards.remove(c)
+        opponents = [deck.draw(2) for _ in range(num_opponents)]
+        community = deck.draw(5)
+
+        hero_score = evaluator.evaluate(hero_cards, community)
+        opp_scores = [evaluator.evaluate(o, community) for o in opponents]
+        best_score = min([hero_score] + opp_scores)
+        num_best = ([hero_score] + opp_scores).count(best_score)
+
+        if hero_score == best_score and num_best == 1:
+            wins += 1
+        elif hero_score == best_score:
+            ties += 1
+
+    win_pct = wins / iterations * 100
+    tie_pct = ties / iterations * 100
+    equity = win_pct + tie_pct / num_opponents
+    return win_pct, tie_pct, equity
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python preflop_sim.py 'As Ks' [num_opponents] [iterations]")
+        return
+    hand = sys.argv[1]
+    num_opponents = int(sys.argv[2]) if len(sys.argv) > 2 else 1
+    iterations = int(sys.argv[3]) if len(sys.argv) > 3 else 10000
+    win, tie, equity = simulate(hand, num_opponents, iterations)
+    print(f"Hand: {hand}")
+    print(f"Opponents: {num_opponents}")
+    print(f"Iterations: {iterations}")
+    print("--------------------------")
+    print(f"Win %: {win:.2f}")
+    print(f"Tie %: {tie:.2f}")
+    print(f"Equity: {equity:.2f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Monte Carlo preflop simulation script using `treys`
- document simulator usage in README

## Testing
- `python3 preflop_sim.py "As Ks" 1 1000`


------
https://chatgpt.com/codex/tasks/task_b_68645d0ee090832dbcc9054f5e858cc9